### PR TITLE
Add go get instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ $ snap install bump
 $ brew install guilhem/homebrew-tap/bump
 ```
 
+### [Go get](https://golang.org/pkg/cmd/go/internal/get/)
+
+```sh
+$ go get github.com/guilhem/bump
+```
+
 ## Usage
 
 ### Help


### PR DESCRIPTION
Might seem obvious, but it took me a second glance before I realized that this was just a go package and I didn't have to install snap